### PR TITLE
Remove accidentally added community requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,12 +10,10 @@ pandas
 statsmodels
 networkx
 seaborn
-community
 python-louvain
 statsmodels
 
 tqdm
-community
 sklearn
 
 # Custom libraries

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
 with open("README.md", "r") as fh:
     long_description = fh.read()
 setuptools.setup(
-     install_requires=['colourmap', 'd3heatmap','pypickle','classeval','wget','d3graph','matplotlib','numpy','pandas','statsmodels','networkx','community','python-louvain','tqdm','sklearn','ismember','imagesc','df2onehot'],
+     install_requires=['colourmap', 'd3heatmap','pypickle','classeval','wget','d3graph','matplotlib','numpy','pandas','statsmodels','networkx','python-louvain','tqdm','sklearn','ismember','imagesc','df2onehot'],
      python_requires='>=3',
      name='hnet',
      version=new_version,


### PR DESCRIPTION
I think that the requiment `community` (https://github.com/ewdurbin/community) was to satisfy the following,

```
from community import community_louvain
```

but it is actually the requirement `python-louvain` (https://github.com/taynaud/python-louvain)

